### PR TITLE
release: 0.5.1

### DIFF
--- a/near-fetch/Cargo.toml
+++ b/near-fetch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-fetch"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "../README.md"

--- a/near-fetch/src/error.rs
+++ b/near-fetch/src/error.rs
@@ -30,6 +30,8 @@ pub enum Error {
     Rpc(Box<dyn std::error::Error + Send + Sync>),
     #[error(transparent)]
     TxExecution(Box<TxExecutionError>),
+    #[error("tx_status={0}")]
+    TxStatus(&'static str),
 
     #[error(transparent)]
     Serialization(#[from] serde_json::Error),

--- a/near-fetch/src/result.rs
+++ b/near-fetch/src/result.rs
@@ -132,7 +132,8 @@ impl ExecutionFinalResult {
                 details: self.details,
             }),
             FinalExecutionStatus::Failure(tx_error) => Err(Error::TxExecution(Box::new(tx_error))),
-            _ => unreachable!(),
+            FinalExecutionStatus::NotStarted => Err(Error::TxStatus("NotStarted")),
+            FinalExecutionStatus::Started => Err(Error::TxStatus("Started")),
         }
     }
 


### PR DESCRIPTION
Includes fixes for when going into unreachable code when calling into `status.await`