### PR TITLE
release: 0.6.0

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,9 +9,9 @@ anyhow = "1"
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 near-account-id = "1.0.0"
-near-crypto = "0.23"
+near-crypto = "0.26"
 near-fetch = { path = "../near-fetch" }
-near-primitives = "0.23"
+near-primitives = "0.26"
 
 [[example]]
 name = "various_views"

--- a/near-fetch/Cargo.toml
+++ b/near-fetch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-fetch"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
@@ -20,12 +20,12 @@ tokio = { version = "1", features = ["full"] }
 tokio-retry = "0.3"
 
 near-account-id = "1"
-near-crypto = "0.23"
-near-gas = { version = "0.2", features = ["serde", "borsh", "schemars"] }
-near-primitives = "0.23"
-near-token = "0.2"
-near-jsonrpc-primitives = "0.23"
-near-jsonrpc-client = { version = "0.10.1", default-features = false }
+near-crypto = "0.26"
+near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
+near-primitives = "0.26"
+near-token = "0.3"
+near-jsonrpc-primitives = "0.26"
+near-jsonrpc-client = { version = "0.13", default-features = false }
 
 [features]
 default = ["rustls-tls"]


### PR DESCRIPTION
- includes the latest updates from NEAR 2.3.0
- **BREAKING**
  - near related dependencies changed `near-crypto` `Signer` trait into an enum so the `SignerExt` had to be changed to reflect this. Without much friction, the `SignerExt` trait had to adopt the methods that `Signer` dropped